### PR TITLE
Minor edits for conflux viewer compatibility

### DIFF
--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -3,7 +3,7 @@ import { WorkerCommandBase, WorkerResponse, OpenSlideT } from "./types";
 type PromiseFns = {
   resolve: (value: WorkerResponse) => void;
   reject: (reason: Error) => void;
-}
+};
 
 function randomString(length: number = 10) {
   let randomName = "";
@@ -18,7 +18,10 @@ class OpenSlideWorker {
   _promiseFns: Map<string, PromiseFns>;
 
   constructor() {
-    this._worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
+    this._worker = new Worker(
+      new URL("./worker.js", import.meta.url),
+      { type: "module" } /* @vite-ignore */,
+    );
     this._worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
       const { data } = event;
       const id = data.id;
@@ -43,7 +46,6 @@ class OpenSlideWorker {
       this._promiseFns.set(id, { resolve, reject });
     });
   }
-
 }
 
 export default class OpenSlide {
@@ -61,8 +63,14 @@ export default class OpenSlide {
     return;
   }
 
-  async open(file: File | string, downloadToLocal: boolean = false): Promise<OpenSlideImage> {
-    const response = await this.worker.sendCommand({ type: "open", payload: { file, downloadToLocal } });
+  async open(
+    file: File | string,
+    downloadToLocal: boolean = false,
+  ): Promise<OpenSlideImage> {
+    const response = await this.worker.sendCommand({
+      type: "open",
+      payload: { file, downloadToLocal },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -73,16 +81,21 @@ export default class OpenSlide {
   }
 }
 
-class OpenSlideImage {
-  constructor(private osr: OpenSlideT, private worker: OpenSlideWorker) {
-  }
+export class OpenSlideImage {
+  constructor(
+    private osr: OpenSlideT,
+    private worker: OpenSlideWorker,
+  ) {}
 
   /**
    * Close the OpenSlide image.
    * @returns A promise that resolves when the image is closed.
    */
   async close() {
-    const response = await this.worker.sendCommand({ type: "close", payload: { osr: this.osr } });
+    const response = await this.worker.sendCommand({
+      type: "close",
+      payload: { osr: this.osr },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -96,7 +109,10 @@ class OpenSlideImage {
    * @returns An array of property names.
    */
   async getPropertyNames(): Promise<string[]> {
-    const response = await this.worker.sendCommand({ type: "getPropertyNames", payload: { osr: this.osr } });
+    const response = await this.worker.sendCommand({
+      type: "getPropertyNames",
+      payload: { osr: this.osr },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -112,7 +128,10 @@ class OpenSlideImage {
    * @returns The value of the property, or null if not found.
    */
   async getPropertyValue(name: string): Promise<string | null> {
-    const response = await this.worker.sendCommand({ type: "getPropertyValue", payload: { osr: this.osr, name } });
+    const response = await this.worker.sendCommand({
+      type: "getPropertyValue",
+      payload: { osr: this.osr, name },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -127,7 +146,10 @@ class OpenSlideImage {
    * @returns The number of levels in the image.
    */
   async getLevelCount(): Promise<number> {
-    const response = await this.worker.sendCommand({ type: "getLevelCount", payload: { osr: this.osr } });
+    const response = await this.worker.sendCommand({
+      type: "getLevelCount",
+      payload: { osr: this.osr },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -143,7 +165,10 @@ class OpenSlideImage {
    * @returns The dimensions of the specified level as a tuple [width, height].
    */
   async getLevelDimensions(level: number): Promise<[number, number]> {
-    const response = await this.worker.sendCommand({ type: "getLevelDimensions", payload: { osr: this.osr, level } });
+    const response = await this.worker.sendCommand({
+      type: "getLevelDimensions",
+      payload: { osr: this.osr, level },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -159,7 +184,10 @@ class OpenSlideImage {
    * @returns The downsample factor for the specified level.
    */
   async getLevelDownsample(level: number): Promise<number> {
-    const response = await this.worker.sendCommand({ type: "getLevelDownsample", payload: { osr: this.osr, level } });
+    const response = await this.worker.sendCommand({
+      type: "getLevelDownsample",
+      payload: { osr: this.osr, level },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -175,7 +203,10 @@ class OpenSlideImage {
    * @returns The best level for the specified downsample factor.
    */
   async getBestLevelForDownsample(downsample: number): Promise<number> {
-    const response = await this.worker.sendCommand({ type: "getBestLevelForDownsample", payload: { osr: this.osr, downsample } });
+    const response = await this.worker.sendCommand({
+      type: "getBestLevelForDownsample",
+      payload: { osr: this.osr, downsample },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -195,8 +226,18 @@ class OpenSlideImage {
    * @param readRgba - Whether to read the region as RGBA (default: false).
    * @returns A promise that resolves to a Uint8ClampedArray containing the pixel data.
    */
-  async readRegion(x: number, y: number, level: number, width: number, height: number, readRgba: boolean = false): Promise<Uint8ClampedArray> {
-    const response = await this.worker.sendCommand({ type: "readRegion", payload: { osr: this.osr, x, y, level, width, height, readRgba } });
+  async readRegion(
+    x: number,
+    y: number,
+    level: number,
+    width: number,
+    height: number,
+    readRgba: boolean = false,
+  ): Promise<Uint8ClampedArray> {
+    const response = await this.worker.sendCommand({
+      type: "readRegion",
+      payload: { osr: this.osr, x, y, level, width, height, readRgba },
+    });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }

--- a/openslide-wasm/src/types.ts
+++ b/openslide-wasm/src/types.ts
@@ -1,29 +1,46 @@
 export type OpenSlideT = number;
 
 export type WorkerCommandBase =
-  | {type: "init"}
-  | {type: "open", payload: {file: File | string, downloadToLocal?: boolean}}
-  | {type: "close", payload: {osr: OpenSlideT}}
-  | {type: "getPropertyNames", payload: {osr: OpenSlideT}}
-  | {type: "getPropertyValue", payload: {osr: OpenSlideT, name: string}}
-  | {type: "getLevelCount", payload: {osr: OpenSlideT}}
-  | {type: "getLevelDimensions", payload: {osr: OpenSlideT, level: number}}
-  | {type: "getLevelDownsample", payload: {osr: OpenSlideT, level: number}}
-  | {type: "getBestLevelForDownsample", payload: {osr: OpenSlideT, downsample: number}}
-  | {type: "readRegion", payload: {osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number, readRgba?: boolean}}
-export type WorkerCommand = WorkerCommandBase & {id: string};
+  | { type: "init" }
+  | {
+      type: "open";
+      payload: { file: File | string; downloadToLocal?: boolean };
+    }
+  | { type: "close"; payload: { osr: OpenSlideT } }
+  | { type: "getPropertyNames"; payload: { osr: OpenSlideT } }
+  | { type: "getPropertyValue"; payload: { osr: OpenSlideT; name: string } }
+  | { type: "getLevelCount"; payload: { osr: OpenSlideT } }
+  | { type: "getLevelDimensions"; payload: { osr: OpenSlideT; level: number } }
+  | { type: "getLevelDownsample"; payload: { osr: OpenSlideT; level: number } }
+  | {
+      type: "getBestLevelForDownsample";
+      payload: { osr: OpenSlideT; downsample: number };
+    }
+  | {
+      type: "readRegion";
+      payload: {
+        osr: OpenSlideT;
+        x: number;
+        y: number;
+        level: number;
+        width: number;
+        height: number;
+        readRgba?: boolean;
+      };
+    };
+export type WorkerCommand = WorkerCommandBase & { id: string };
 
 export type WorkerResponseBase =
-  | {type: "error", payload: {message: string}}
-  | {type: "ready"}
-  | {type: "open", payload: {osr: OpenSlideT}}
-  | {type: "close", payload: {osr: OpenSlideT}}
-  | {type: "getPropertyNames", payload: {names: string[]}}
-  | {type: "getPropertyValue", payload: {value: string | null}}
-  | {type: "getLevelCount", payload: {count: number}}
-  | {type: "getLevelDimensions", payload: {dimensions: [number, number]}}
-  | {type: "getLevelDownsample", payload: {downsample: number}}
-  | {type: "getBestLevelForDownsample", payload: {level: number}}
-  | {type: "readRegion", payload: {data: Uint8ClampedArray};}
+  | { type: "error"; payload: { message: string } }
+  | { type: "ready" }
+  | { type: "open"; payload: { osr: OpenSlideT } }
+  | { type: "close"; payload: { osr: OpenSlideT } }
+  | { type: "getPropertyNames"; payload: { names: string[] } }
+  | { type: "getPropertyValue"; payload: { value: string | null } }
+  | { type: "getLevelCount"; payload: { count: number } }
+  | { type: "getLevelDimensions"; payload: { dimensions: [number, number] } }
+  | { type: "getLevelDownsample"; payload: { downsample: number } }
+  | { type: "getBestLevelForDownsample"; payload: { level: number } }
+  | { type: "readRegion"; payload: { data: Uint8ClampedArray } };
 
-export type WorkerResponse = WorkerResponseBase & {id: string};
+export type WorkerResponse = WorkerResponseBase & { id: string };

--- a/openslide-wasm/src/worker.ts
+++ b/openslide-wasm/src/worker.ts
@@ -11,11 +11,14 @@ const _TMP_LOCAL_PREFIX = "/tmp-local-";
 type Pointer = number;
 
 declare var WORKERFS: Emscripten.FileSystemType;
-declare function cwrap<I extends Array<Emscripten.JSType | null> | [], R extends Emscripten.JSType | null>(
-    ident: string,
-    returnType: R,
-    argTypes: I,
-    opts: {async: true},
+declare function cwrap<
+  I extends Array<Emscripten.JSType | null> | [],
+  R extends Emscripten.JSType | null,
+>(
+  ident: string,
+  returnType: R,
+  argTypes: I,
+  opts: { async: true },
 ): (...arg: ArgsToType<I>) => Promise<ReturnToType<R>>;
 
 interface OpenSlideEmscriptenModule extends EmscriptenModule {
@@ -25,7 +28,6 @@ interface OpenSlideEmscriptenModule extends EmscriptenModule {
   UTF8ToString: typeof UTF8ToString;
 }
 
-
 function randomString(length: number = 10) {
   let randomName = "";
   for (let i = 0; i < length; i++) {
@@ -33,7 +35,6 @@ function randomString(length: number = 10) {
   }
   return randomName;
 }
-
 
 async function fetchFileFromUrl(url: string) {
   const response = await fetch(url);
@@ -44,30 +45,80 @@ async function fetchFileFromUrl(url: string) {
   return file;
 }
 
-
 class OpenSlideApi {
   private _getPropertyNamesAsync: (osr: OpenSlideT) => Promise<Pointer>;
-  private _getPropertyValueAsync: (osr: OpenSlideT, name: string) => Promise<Pointer>;
+  private _getPropertyValueAsync: (
+    osr: OpenSlideT,
+    name: string,
+  ) => Promise<Pointer>;
   private _getLevelCountAsync: (osr: OpenSlideT) => Promise<number>;
-  private _getLevelDimensionsAsync: (osr: OpenSlideT, level: number) => Promise<number>;
-  private _getLevelDownsampleAsync: (osr: OpenSlideT, level: number) => Promise<number>;
-  private _getBestLevelForDownsampleAsync: (osr: OpenSlideT, downsample: number) => Promise<number>;
+  private _getLevelDimensionsAsync: (
+    osr: OpenSlideT,
+    level: number,
+  ) => Promise<number>;
+  private _getLevelDownsampleAsync: (
+    osr: OpenSlideT,
+    level: number,
+  ) => Promise<number>;
+  private _getBestLevelForDownsampleAsync: (
+    osr: OpenSlideT,
+    downsample: number,
+  ) => Promise<number>;
   private _readRegionAsync: (osr: OpenSlideT, args: number) => Promise<number>;
   private _openSlideAsync: (filepath: string) => Promise<OpenSlideT>;
   private _closeSlideAsync: (osr: OpenSlideT) => Promise<null>;
   private _osrMountMap: Map<OpenSlideT, string>;
 
   constructor(private lib: OpenSlideEmscriptenModule) {
-    this._getPropertyNamesAsync = lib.cwrap("get_property_names", "number", ["number"], {async: true});
-    this._getPropertyValueAsync = lib.cwrap("get_property_value", "number", ["number", "string"], {async: true});
-    this._getLevelCountAsync = lib.cwrap("get_level_count", "number", ["number"], {async: true});
-    this._getLevelDimensionsAsync = lib.cwrap("get_level_dimensions", "number", ["number", "number"], {async: true});
-    this._getLevelDownsampleAsync = lib.cwrap("get_level_downsample", "number", ["number", "number"], {async: true});
-    this._getBestLevelForDownsampleAsync = lib.cwrap("get_best_level_for_downsample", "number", ["number", "number"], {async: true});
-    this._readRegionAsync = lib.cwrap("read_region", "number", ["number", "number"], {async: true});
+    this._getPropertyNamesAsync = lib.cwrap(
+      "get_property_names",
+      "number",
+      ["number"],
+      { async: true },
+    );
+    this._getPropertyValueAsync = lib.cwrap(
+      "get_property_value",
+      "number",
+      ["number", "string"],
+      { async: true },
+    );
+    this._getLevelCountAsync = lib.cwrap(
+      "get_level_count",
+      "number",
+      ["number"],
+      { async: true },
+    );
+    this._getLevelDimensionsAsync = lib.cwrap(
+      "get_level_dimensions",
+      "number",
+      ["number", "number"],
+      { async: true },
+    );
+    this._getLevelDownsampleAsync = lib.cwrap(
+      "get_level_downsample",
+      "number",
+      ["number", "number"],
+      { async: true },
+    );
+    this._getBestLevelForDownsampleAsync = lib.cwrap(
+      "get_best_level_for_downsample",
+      "number",
+      ["number", "number"],
+      { async: true },
+    );
+    this._readRegionAsync = lib.cwrap(
+      "read_region",
+      "number",
+      ["number", "number"],
+      { async: true },
+    );
     // TODO: consider changing the names "load_image" and "close_image"
-    this._openSlideAsync = lib.cwrap("load_image", "number", ["string"], {async: true});
-    this._closeSlideAsync = lib.cwrap("close_image", null, ["number"], {async: true});
+    this._openSlideAsync = lib.cwrap("load_image", "number", ["string"], {
+      async: true,
+    });
+    this._closeSlideAsync = lib.cwrap("close_image", null, ["number"], {
+      async: true,
+    });
     this._osrMountMap = new Map();
   }
 
@@ -98,7 +149,10 @@ class OpenSlideApi {
     return count;
   }
 
-  async getLevelDimensions(osr: OpenSlideT, level: number): Promise<[number, number]> {
+  async getLevelDimensions(
+    osr: OpenSlideT,
+    level: number,
+  ): Promise<[number, number]> {
     const result = await this._getLevelDimensionsAsync(osr, level);
     const int64View = new BigInt64Array(this.lib.HEAP8.buffer, result, 2);
     const w = int64View[0];
@@ -117,7 +171,15 @@ class OpenSlideApi {
     return level;
   }
 
-  async readRegion(osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number, readRgba: boolean = false) {
+  async readRegion(
+    osr: OpenSlideT,
+    x: number,
+    y: number,
+    level: number,
+    width: number,
+    height: number,
+    readRgba: boolean = false,
+  ) {
     // We malloc memory to pack all values into a single chunk of memory
     const args = this.lib._malloc(40);
     this.lib.HEAP64[args / 8] = BigInt(x); // int64_t x (8 bytes)
@@ -132,17 +194,13 @@ class OpenSlideApi {
     this.lib._free(args);
 
     const sz = width * height * 4;
-    const imageArray = new Uint8ClampedArray(
-      this.lib.HEAPU8.buffer,
-      data,
-      sz,
-    );
+    const imageArray = new Uint8ClampedArray(this.lib.HEAPU8.buffer, data, sz);
     this.lib._free(data);
     return imageArray;
   }
 
   async open(file: File | string, downloadToLocal: boolean = false) {
-    const {filename, mountDir} = await this._open_file(file, downloadToLocal);
+    const { filename, mountDir } = await this._open_file(file, downloadToLocal);
     const filepath = mountDir ? `${mountDir}/${filename}` : filename;
     const osr = await this._openSlideAsync(filepath);
     if (mountDir) {
@@ -176,7 +234,7 @@ class OpenSlideApi {
   _mount_file(file: File) {
     const dirname = `${_TMP_LOCAL_PREFIX}${randomString()}`;
     this.lib.FS.mkdir(dirname);
-    this.lib.FS.mount(this.lib.WORKERFS, { files: [file] }, dirname)
+    this.lib.FS.mount(this.lib.WORKERFS, { files: [file] }, dirname);
     return dirname;
   }
 
@@ -193,100 +251,121 @@ class OpenSlideApi {
 
 let api: OpenSlideApi | undefined = undefined;
 
-
-
 function doPostMessage(id: string, message: WorkerResponseBase) {
-  self.postMessage({id, ...message});
+  self.postMessage({ id, ...message });
 }
 
 self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
-  const {data} = e;
-  const {id} = data;
+  const { data } = e;
+  const { id } = data;
   if (data.type === "init") {
     if (api) {
-      doPostMessage(id, {type: "error",payload: {message: "OpenSlide API already initialized"}});
+      doPostMessage(id, {
+        type: "error",
+        payload: { message: "OpenSlide API already initialized" },
+      });
       return;
     }
     const lib = await createModule();
     api = new OpenSlideApi(lib);
-    doPostMessage(id, {type: "ready"});
+    doPostMessage(id, { type: "ready" });
     return;
-  };
+  }
 
   if (!api) {
-    doPostMessage(id, {type: "error", payload: {message: "OpenSlide API not initialized"}});
+    doPostMessage(id, {
+      type: "error",
+      payload: { message: "OpenSlide API not initialized" },
+    });
     return;
   }
 
   try {
     await handleMessage(api, data);
   } catch (error) {
-    doPostMessage(id, {type: "error", payload: {message: (error as Error).message}});
+    doPostMessage(id, {
+      type: "error",
+      payload: { message: (error as Error).message },
+    });
   }
-}
+};
 
-async function handleMessage(
-  api: OpenSlideApi,
-  data: WorkerCommand,
-) {
-  const {id} = data;
-  const {type: dataType} = data;
+async function handleMessage(api: OpenSlideApi, data: WorkerCommand) {
+  const { id } = data;
+  const { type: dataType } = data;
   switch (dataType) {
     case "init": {
       break;
     }
     case "open": {
-      const {file, downloadToLocal} = data.payload;
+      const { file, downloadToLocal } = data.payload;
       const osr = await api.open(file, downloadToLocal);
-      doPostMessage(id, {type: "open", payload: {osr}});
+      doPostMessage(id, { type: "open", payload: { osr } });
       break;
     }
     case "close": {
-      const {osr} = data.payload;
+      const { osr } = data.payload;
       await api.close(osr);
-      doPostMessage(id, {type: "close", payload: {osr}});
+      doPostMessage(id, { type: "close", payload: { osr } });
       break;
     }
     case "getPropertyNames": {
-      const {osr} = data.payload;
+      const { osr } = data.payload;
       const names = await api.getPropertyNames(osr);
-      doPostMessage(id, {type: "getPropertyNames", payload: {names}});
+      doPostMessage(id, { type: "getPropertyNames", payload: { names } });
       break;
     }
     case "getPropertyValue": {
-      const {osr, name} = data.payload;
+      const { osr, name } = data.payload;
       const value = await api.getPropertyValue(osr, name);
-      doPostMessage(id, {type: "getPropertyValue", payload: {value}});
+      doPostMessage(id, { type: "getPropertyValue", payload: { value } });
       break;
     }
     case "getLevelCount": {
-      const {osr} = data.payload;
+      const { osr } = data.payload;
       const count = await api.getLevelCount(osr);
-      doPostMessage(id, {type: "getLevelCount", payload: {count}});
+      doPostMessage(id, { type: "getLevelCount", payload: { count } });
       break;
     }
     case "getLevelDimensions": {
-      const {osr, level} = data.payload;
+      const { osr, level } = data.payload;
       const dimensions = await api.getLevelDimensions(osr, level);
-      doPostMessage(id, {type: "getLevelDimensions", payload: {dimensions}});
+      doPostMessage(id, {
+        type: "getLevelDimensions",
+        payload: { dimensions },
+      });
       break;
     }
     case "getLevelDownsample": {
-      const {osr, level} = data.payload;
+      const { osr, level } = data.payload;
       const downsample = await api.getLevelDownsample(osr, level);
-      doPostMessage(id, {type: "getLevelDownsample", payload: {downsample}});
+      doPostMessage(id, {
+        type: "getLevelDownsample",
+        payload: { downsample },
+      });
       break;
     }
     case "getBestLevelForDownsample": {
-      const {osr, downsample} = data.payload;
+      const { osr, downsample } = data.payload;
       const level = await api.getBestLevelForDownsample(osr, downsample);
-      doPostMessage(id, {type: "getBestLevelForDownsample", payload: {level}});
+      doPostMessage(id, {
+        type: "getBestLevelForDownsample",
+        payload: { level },
+      });
       break;
     }
     case "readRegion": {
-      const {osr, x, y, level, width, height, readRgba} = data.payload;
-      const regionData = await api.readRegion(osr, x, y, level, width, height, readRgba);
-      doPostMessage(id, {type: "readRegion", payload: {data: regionData}});
+      const { osr, x, y, level, width, height, readRgba } = data.payload;
+      const regionData = await api.readRegion(
+        osr,
+        x,
+        y,
+        level,
+        width,
+        height,
+        readRgba,
+      );
+      doPostMessage(id, { type: "readRegion", payload: { data: regionData } });
       break;
     }
     default:

--- a/openslide-wasm/tests/openslide.test.js
+++ b/openslide-wasm/tests/openslide.test.js
@@ -107,13 +107,10 @@ describe("Test OpenSlide (HTTP file system)", () => {
   }, 30000);
 
   it("should load the property names and values", async () => {
-    const {
-      names,
-      value,
-    } = await page.evaluate(async () => {
+    const { names, value } = await page.evaluate(async () => {
       const names = await window.slide_remote_fs.getPropertyNames();
       const value = await window.slide_remote_fs.getPropertyValue(names[0]);
-      return {names, value};
+      return { names, value };
     });
     expect(names[0]).toBe("aperio.AppMag");
     expect(names.length).toBe(57);
@@ -121,21 +118,20 @@ describe("Test OpenSlide (HTTP file system)", () => {
   });
 
   it("should respond with the right downsample level information", async () => {
-    const {
-      levelCount,
-      levelDownsample,
-      bestDownsample,
-    } = await page.evaluate(async () => {
-      const levelCount = await window.slide_remote_fs.getLevelCount();
-      const levelDownsample = await window.slide_remote_fs.getLevelDownsample(1);
-      const bestDownsample = await window.slide_remote_fs.getBestLevelForDownsample(20);
-      return {levelCount, levelDownsample, bestDownsample};
-    });
+    const { levelCount, levelDownsample, bestDownsample } = await page.evaluate(
+      async () => {
+        const levelCount = await window.slide_remote_fs.getLevelCount();
+        const levelDownsample =
+          await window.slide_remote_fs.getLevelDownsample(1);
+        const bestDownsample =
+          await window.slide_remote_fs.getBestLevelForDownsample(20);
+        return { levelCount, levelDownsample, bestDownsample };
+      },
+    );
     expect(levelCount).toBe(4);
     expect(levelDownsample).toBeCloseTo(4.0, 3);
     expect(bestDownsample).toBe(2);
   });
-
 
   it("should have the right dimensions", async () => {
     const [level0] = await page.evaluate(async () => {


### PR DESCRIPTION
- Importing the web worker failed due to the dev server: https://stackoverflow.com/questions/76010614/vite-web-workers-failing-on-dev-server ... added vite ignore
- Need OpenSlideImage to be exported as it's often used externally

EDIT: Sorry, it seems there is not default prettier config -- so this added tons of edits. I highlighted the changes below.