### PR TITLE
Export type for OpenSlideImage class

### DIFF
--- a/openslide-wasm/package.json
+++ b/openslide-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conflux-xyz/openslide-wasm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "type": "module",
   "main": "dist/openslide.js",

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -229,3 +229,5 @@ class OpenSlideImage {
     return response.payload.data;
   }
 }
+
+export type { OpenSlideImage };


### PR DESCRIPTION
This exports the `OpenSlideImage` class as a type, but not the class itself since it should not be constructed using `new` anyway -- it should only be constructed from `OpenSlide#open`.