### PR TITLE
Enable multiple workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use the library you just need to add `openslide.js` directory to your web pro
 <script language="javascript" type="module">
   import OpenSlide from "./openslide.js";
   async function run() {
-   const ctx = new OpenSlide();
+   const ctx = new OpenSlide({workers: 1});
    await ctx.initialize();
    const image = await ctx.open("sample.svs");
    const numLevels = await image.getLevelCount();

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -5,7 +5,7 @@
       import OpenSlide from "/openslide-wasm/dist/openslide.js";
 
       async function initialize() {
-        window.openslide = new OpenSlide(4);
+        window.openslide = new OpenSlide({workers: 4});
         console.log('created');
         await openslide.initialize();
         console.log('initialized');

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -5,7 +5,7 @@
       import OpenSlide from "/openslide-wasm/dist/openslide.js";
 
       async function initialize() {
-        window.openslide = new OpenSlide();
+        window.openslide = new OpenSlide(4);
         console.log('created');
         await openslide.initialize();
         console.log('initialized');
@@ -17,25 +17,19 @@
 
       const downloadRemoteCheckbox = document.getElementById("downloadRemote");
       const mppInput = document.getElementById("mpp");
+      const numPartitionsInput = document.getElementById("num-partitions");
       const fileInput = document.getElementById("file");
       const remoteUrlInput = document.getElementById("remoteUrl");
       const loadRemoteButton = document.getElementById("loadRemote");
       const clearButton = document.getElementById("clear");
-      const canvases = [0, 1, 2, 3].map((i) => document.getElementById(`image${i}`));
-      const ctx2ds = canvases.map((canvas) => {
-        const ctx2d = canvas.getContext("2d");
-        if (!ctx2d) {
-          throw new Error("Failed to get 2D context");
-        }
-        return ctx2d;
-      });
+      const canvasContainer = document.getElementById("canvas-container");
 
       const handleSlide = async (slide) => {
         clearButton.onclick = async () => {
           console.log('closing...');
           await slide.close();
           fileInput.value = null;
-          ctx2ds.forEach((ctx2d) => ctx2d.reset());
+          canvasContainer.innerHTML = "";
           console.log('closed');
         };
         console.log('opened');
@@ -47,6 +41,8 @@
         const slideMpp = parseFloat(slideMppStr);
         console.log("Slide MPP", slideMpp);
         const mpp = parseFloat(mppInput.value);
+        const numPartitions = parseInt(numPartitionsInput.value);
+        canvasContainer.style.gridTemplateColumns = `repeat(${numPartitions}, auto)`;
         const downsample = mpp / slideMpp;
         const [width, height] = await slide.getLevelDimensions(0);
         const targetWidth = Math.round(width / downsample);
@@ -57,38 +53,44 @@
         console.log("Best level for downsample", bestLevel);
         const [levelWidth, levelHeight] = await slide.getLevelDimensions(bestLevel);
         console.log('level dims', levelWidth, levelHeight);
-        const region = await slide.readRegion(0, 0, bestLevel, levelWidth, levelHeight, true);
-        const halfWidth = Math.floor(width / 2);
-        const halfHeight = Math.floor(height / 2);
-        const halfLevelWidth = Math.floor(levelWidth / 2);
-        const halfLevelHeight = Math.floor(levelHeight / 2);
-        const halfTargetWidth = Math.floor(targetWidth / 2);
-        const halfTargetHeight = Math.floor(targetHeight / 2);
-        const regions = [
-          [0, 0],
-          [halfWidth, 0],
-          [0, halfHeight],
-          [halfWidth, halfHeight],
-        ];
-        const regionPromises = regions.map(([x, y]) => {
-          return slide.readRegion(x, y, bestLevel, halfLevelWidth, halfLevelHeight, true);
-        });
+
+        const regionWidth = Math.floor(width / numPartitions);
+        const regionHeight = Math.floor(height / numPartitions);
+        const regionLevelWidth = Math.floor(levelWidth / numPartitions);
+        const regionLevelHeight = Math.floor(levelHeight / numPartitions);
+        const regionTargetWidth = Math.floor(targetWidth / numPartitions);
+        const regionTargetHeight = Math.floor(targetHeight / numPartitions);
+
+        const regionPromises = [];
+        for (let j = 0; j < numPartitions; j++) {
+          for (let i = 0; i < numPartitions; i++) {
+            const x = i * regionWidth;
+            const y = j * regionHeight;
+            regionPromises.push(
+              slide.readRegion(x, y, bestLevel, regionLevelWidth, regionLevelHeight, true)
+            );
+          }
+        }
+        console.time('readRegion');
         const allRegions = await Promise.all(regionPromises);
+        console.timeEnd('readRegion');
         allRegions.forEach(async (region, index) => {
-          const canvas = canvases[index];
-          const ctx2d = ctx2ds[index];
-          canvas.width = halfLevelWidth;
-          canvas.height = halfLevelHeight;
-          const imageData = new ImageData(region, halfLevelWidth, halfLevelHeight);
+          const imageData = new ImageData(region, regionLevelWidth, regionLevelHeight);
 
           // Resize the image tile data to the desired width and height
           const bitmap = await createImageBitmap(imageData, {
-            resizeWidth: halfTargetWidth,
-            resizeHeight: halfTargetHeight,
+            resizeWidth: regionTargetWidth,
+            resizeHeight: regionTargetHeight,
           });
-          canvas.width = halfTargetWidth;
-          canvas.height = halfTargetHeight;
+
+          const canvas = document.createElement("canvas");
+          const ctx2d = canvas.getContext("2d");
+          canvas.style.border = "1px solid black";
+          canvas.width = regionTargetWidth;
+          canvas.height = regionTargetHeight;
           ctx2d.drawImage(bitmap, 0, 0);
+
+          canvasContainer.appendChild(canvas);
         });
       }
 
@@ -128,15 +130,13 @@
       <input type="number" id="mpp" placeholder="MPP" value="40.0" step="0.01"/>
     </div>
     <div>
+      <label for="num-partitions">Partitions</label>
+      <input type="number" id="num-partitions" placeholder="Num Partitions" value="4" step="1"/>
+    </div>
+    <div>
       <button id="clear">Clear</button>
     </div>
-    <div style="display: flex; flex-direction: row;">
-      <canvas id="image0" width="1px" height="1px" style="border: 1px solid black;"></canvas>
-      <canvas id="image1" width="1px" height="1px" style="border: 1px solid black;"></canvas>
-    </div>
-    <div style="display: flex; flex-direction: row;">
-      <canvas id="image2" width="1px" height="1px" style="border: 1px solid black;"></canvas>
-      <canvas id="image3" width="1px" height="1px" style="border: 1px solid black;"></canvas>
+    <div id="canvas-container" style="display: inline-grid; grid-template-columns: repeat(2, auto);">
     </div>
     </div>
   </body>

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -74,8 +74,12 @@ export default class OpenSlide {
 
   async open(file: File | URL | string, downloadToLocal: boolean = false): Promise<OpenSlideImage> {
     const fileOrUrl = ensureFileOrUrl(file);
+    if (fileOrUrl instanceof URL && downloadToLocal) {
+      const file = await fetchFileFromUrl(fileOrUrl);
+      return await this.open(file, false);
+    }
     const fileOrString = fileOrUrl instanceof URL ? fileOrUrl.toString() : fileOrUrl;
-    const responses = await Promise.all(this.workers.map((w) => w.sendCommand({ type: "open", payload: { file: fileOrString, downloadToLocal } })));
+    const responses = await Promise.all(this.workers.map((w) => w.sendCommand({ type: "open", payload: { file: fileOrString } })));
     const handles = responses.map((response, idx) => {
       if (response.type === "error") {
         throw new Error(response.payload.message);
@@ -111,6 +115,18 @@ function ensureFileOrUrl(file: File | URL | string): File | URL {
   } catch (e) {
     throw new Error("Invalid URL");
   }
+}
+
+
+async function fetchFileFromUrl(url: URL) {
+  const filename = url.pathname.split("/").pop() || "filename";
+  console.log("Fetching file from URL:", url.toString());
+  const response = await fetch(url.toString());
+  console.log("Response status:", response.status);
+  const blob = await response.blob();
+  console.log("Blob size:", blob.size);
+  const file = new File([blob], filename, { type: blob.type });
+  return file;
 }
 
 

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -24,11 +24,12 @@ class OpenSlideWorker {
     this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
       const { data } = event;
       const id = data.id;
-      const promiseFns = this.promiseFns.get(id);
-      if (!promiseFns) {
+      const promiseFn = this.promiseFns.get(id);
+      if (!promiseFn) {
         return;
       }
-      const { resolve, reject } = promiseFns;
+      this.promiseFns.delete(id);
+      const { resolve, reject } = promiseFn;
       if (data.type === "error") {
         reject(new Error(data.payload.message));
       } else {

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -14,15 +14,17 @@ function randomString(length: number = 10) {
 }
 
 class OpenSlideWorker {
-  _worker: Worker;
-  _promiseFns: Map<string, PromiseFns>;
+  id: string;
+  private worker: Worker;
+  private promiseFns: Map<string, PromiseFns>;
 
   constructor() {
-    this._worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
-    this._worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+    this.id = randomString(16);
+    this.worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
+    this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
       const { data } = event;
       const id = data.id;
-      const promiseFns = this._promiseFns.get(id);
+      const promiseFns = this.promiseFns.get(id);
       if (!promiseFns) {
         return;
       }
@@ -33,30 +35,39 @@ class OpenSlideWorker {
         resolve(data);
       }
     };
-    this._promiseFns = new Map();
+    this.promiseFns = new Map();
+  }
+
+  numTasks(): number {
+    return this.promiseFns.size;
   }
 
   sendCommand(command: WorkerCommandBase): Promise<WorkerResponse> {
     const id = randomString(16);
     return new Promise<WorkerResponse>((resolve, reject) => {
-      this._worker.postMessage({ ...command, id });
-      this._promiseFns.set(id, { resolve, reject });
+      this.worker.postMessage({ ...command, id });
+      this.promiseFns.set(id, { resolve, reject });
     });
   }
 
 }
 
 export default class OpenSlide {
-  private worker: OpenSlideWorker;
+  private workers: OpenSlideWorker[];
 
-  constructor() {
-    this.worker = new OpenSlideWorker();
+  constructor(workerPoolSize: number = 1) {
+    this.workers = [];
+    for (let i = 0; i < workerPoolSize; i++) {
+      this.workers.push(new OpenSlideWorker());
+    }
   }
 
   async initialize() {
-    const p = await this.worker.sendCommand({ type: "init" });
-    if (p.type === "error") {
-      throw new Error(p.payload.message);
+    const results = await Promise.all(this.workers.map((w) => w.sendCommand({ type: "init" })));
+    for (const p of results) {
+      if (p.type === "error") {
+        throw new Error(p.payload.message);
+      }
     }
     return;
   }
@@ -64,14 +75,20 @@ export default class OpenSlide {
   async open(file: File | URL | string, downloadToLocal: boolean = false): Promise<OpenSlideImage> {
     const fileOrUrl = ensureFileOrUrl(file);
     const fileOrString = fileOrUrl instanceof URL ? fileOrUrl.toString() : fileOrUrl;
-    const response = await this.worker.sendCommand({ type: "open", payload: { file: fileOrString, downloadToLocal } });
-    if (response.type === "error") {
-      throw new Error(response.payload.message);
-    }
-    if (response.type !== "open") {
-      throw new Error("Unexpected response type");
-    }
-    return new OpenSlideImage(response.payload.osr, this.worker);
+    const responses = await Promise.all(this.workers.map((w) => w.sendCommand({ type: "open", payload: { file: fileOrString, downloadToLocal } })));
+    const handles = responses.map((response, idx) => {
+      if (response.type === "error") {
+        throw new Error(response.payload.message);
+      }
+      if (response.type !== "open") {
+        throw new Error("Unexpected response type");
+      }
+      return {
+        osr: response.payload.osr,
+        worker: this.workers[idx],
+      };
+    });
+    return new OpenSlideImage(handles);
   }
 }
 
@@ -96,8 +113,14 @@ function ensureFileOrUrl(file: File | URL | string): File | URL {
   }
 }
 
+
+interface OpenSlideHandle {
+  osr: OpenSlideT;
+  worker: OpenSlideWorker;
+}
+
 class OpenSlideImage {
-  constructor(private osr: OpenSlideT, private worker: OpenSlideWorker) {
+  constructor(private handles: OpenSlideHandle[]) {
   }
 
   /**
@@ -105,21 +128,36 @@ class OpenSlideImage {
    * @returns A promise that resolves when the image is closed.
    */
   async close() {
-    const response = await this.worker.sendCommand({ type: "close", payload: { osr: this.osr } });
-    if (response.type === "error") {
-      throw new Error(response.payload.message);
-    }
-    if (response.type !== "close") {
-      throw new Error("Unexpected response type");
+    const responses = await Promise.all(this.handles.map(({osr, worker}) => worker.sendCommand({ type: "close", payload: { osr } })));
+    for (const response of responses) {
+      if (response.type === "error") {
+        throw new Error(response.payload.message);
+      }
+      if (response.type !== "close") {
+        throw new Error("Unexpected response type");
+      }
     }
   }
+
+
+  private getHandle(): OpenSlideHandle {
+    const sizes = this.handles.map((h) => h.worker.numTasks());
+    const minSize = Math.min(...sizes);
+    const minHandles = this.handles.filter((_, idx) => sizes[idx] === minSize);
+    const possibleHandles = minHandles.length === 0 ? this.handles : minHandles;
+    const index = Math.floor(Math.random() * possibleHandles.length);
+    const handle = possibleHandles[index];
+    return handle;
+  }
+
 
   /**
    * Get the names of all properties in the image.
    * @returns An array of property names.
    */
   async getPropertyNames(): Promise<string[]> {
-    const response = await this.worker.sendCommand({ type: "getPropertyNames", payload: { osr: this.osr } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "getPropertyNames", payload: { osr } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -135,7 +173,8 @@ class OpenSlideImage {
    * @returns The value of the property, or null if not found.
    */
   async getPropertyValue(name: string): Promise<string | null> {
-    const response = await this.worker.sendCommand({ type: "getPropertyValue", payload: { osr: this.osr, name } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "getPropertyValue", payload: { osr, name } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -150,7 +189,8 @@ class OpenSlideImage {
    * @returns The number of levels in the image.
    */
   async getLevelCount(): Promise<number> {
-    const response = await this.worker.sendCommand({ type: "getLevelCount", payload: { osr: this.osr } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "getLevelCount", payload: { osr } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -166,7 +206,8 @@ class OpenSlideImage {
    * @returns The dimensions of the specified level as a tuple [width, height].
    */
   async getLevelDimensions(level: number): Promise<[number, number]> {
-    const response = await this.worker.sendCommand({ type: "getLevelDimensions", payload: { osr: this.osr, level } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "getLevelDimensions", payload: { osr, level } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -182,7 +223,8 @@ class OpenSlideImage {
    * @returns The downsample factor for the specified level.
    */
   async getLevelDownsample(level: number): Promise<number> {
-    const response = await this.worker.sendCommand({ type: "getLevelDownsample", payload: { osr: this.osr, level } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "getLevelDownsample", payload: { osr, level } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -198,7 +240,8 @@ class OpenSlideImage {
    * @returns The best level for the specified downsample factor.
    */
   async getBestLevelForDownsample(downsample: number): Promise<number> {
-    const response = await this.worker.sendCommand({ type: "getBestLevelForDownsample", payload: { osr: this.osr, downsample } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "getBestLevelForDownsample", payload: { osr, downsample } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }
@@ -219,7 +262,8 @@ class OpenSlideImage {
    * @returns A promise that resolves to a Uint8ClampedArray containing the pixel data.
    */
   async readRegion(x: number, y: number, level: number, width: number, height: number, readRgba: boolean = false): Promise<Uint8ClampedArray> {
-    const response = await this.worker.sendCommand({ type: "readRegion", payload: { osr: this.osr, x, y, level, width, height, readRgba } });
+    const { osr, worker } = this.getHandle();
+    const response = await worker.sendCommand({ type: "readRegion", payload: { osr, x, y, level, width, height, readRgba } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -53,19 +53,28 @@ class OpenSlideWorker {
 
 }
 
+export interface OpenSlideOptions {
+  workers?: number;
+}
 export default class OpenSlide {
   private workers: OpenSlideWorker[];
 
   /**
    * Creates an instance of OpenSlide with a specified number of workers.
    * 
-   * @param {number} [workerPoolSize=1] - The number of workers to initialize in the pool.
-   * Must be a positive integer. A larger pool size may improve performance for
-   * concurrent tasks but will consume more system resources.
+   * @param {OpenSlideOptions} options - Options for OpenSlide.
+   * @param {number} options.workers - The number of workers to create (default: 1).
+   * @returns {OpenSlide} An instance of OpenSlide.
+   * @throws {Error} If the number of workers is less than 1.
    */
-  constructor(workerPoolSize: number = 1) {
+  constructor({
+    workers = 1,
+  }: OpenSlideOptions) {
+    if (workers < 1) {
+      throw new Error("Number of workers must be at least 1");
+    }
     this.workers = [];
-    for (let i = 0; i < workerPoolSize; i++) {
+    for (let i = 0; i < workers; i++) {
       this.workers.push(new OpenSlideWorker());
     }
   }

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -56,6 +56,13 @@ class OpenSlideWorker {
 export default class OpenSlide {
   private workers: OpenSlideWorker[];
 
+  /**
+   * Creates an instance of OpenSlide with a specified number of workers.
+   * 
+   * @param {number} [workerPoolSize=1] - The number of workers to initialize in the pool.
+   * Must be a positive integer. A larger pool size may improve performance for
+   * concurrent tasks but will consume more system resources.
+   */
   constructor(workerPoolSize: number = 1) {
     this.workers = [];
     for (let i = 0; i < workerPoolSize; i++) {

--- a/openslide-wasm/src/types.ts
+++ b/openslide-wasm/src/types.ts
@@ -2,7 +2,7 @@ export type OpenSlideT = number;
 
 export type WorkerCommandBase =
   | {type: "init"}
-  | {type: "open", payload: {file: File | string, downloadToLocal?: boolean}}
+  | {type: "open", payload: {file: File | string}}
   | {type: "close", payload: {osr: OpenSlideT}}
   | {type: "getPropertyNames", payload: {osr: OpenSlideT}}
   | {type: "getPropertyValue", payload: {osr: OpenSlideT, name: string}}

--- a/openslide-wasm/src/worker.ts
+++ b/openslide-wasm/src/worker.ts
@@ -33,15 +33,6 @@ function randomString(length: number = 10) {
 }
 
 
-async function fetchFileFromUrl(url: URL) {
-  const filename = url.pathname.split("/").pop() || "filename";
-  const response = await fetch(url.toString());
-  const blob = await response.blob();
-  const file = new File([blob], filename, { type: blob.type });
-  return file;
-}
-
-
 class OpenSlideApi {
   private _getPropertyNamesAsync: (osr: OpenSlideT) => Promise<Pointer>;
   private _getPropertyValueAsync: (osr: OpenSlideT, name: string) => Promise<Pointer>;
@@ -144,9 +135,9 @@ class OpenSlideApi {
     return imageArray;
   }
 
-  async open(file: File | string, downloadToLocal: boolean = false) {
+  async open(file: File | string) {
     const fileOrUrl = file instanceof File ? file : new URL(file);
-    const {filename, mountDir} = await this._open_file(fileOrUrl, downloadToLocal);
+    const {filename, mountDir} = await this._open_file(fileOrUrl);
     const filepath = mountDir ? `${mountDir}/${filename}` : filename;
     const osr = await this._openSlideAsync(filepath);
     if (mountDir) {
@@ -155,20 +146,12 @@ class OpenSlideApi {
     return osr;
   }
 
-  async _open_file(file: File | URL, downloadToLocal: boolean = false) {
+  async _open_file(file: File | URL) {
     if (file instanceof URL) {
-      if (downloadToLocal) {
-        const fileObj = await fetchFileFromUrl(file);
-        return {
-          filename: fileObj.name,
-          mountDir: this._mount_file(fileObj),
-        };
-      } else {
-        return {
-          filename: "remote",
-          mountDir: this._mount_url(file),
-        };
-      }
+      return {
+        filename: "remote",
+        mountDir: this._mount_url(file),
+      };
     } else {
       return {
         filename: file.name,
@@ -248,8 +231,8 @@ async function handleMessage(
       break;
     }
     case "open": {
-      const {file, downloadToLocal} = data.payload;
-      const osr = await api.open(file, downloadToLocal);
+      const {file} = data.payload;
+      const osr = await api.open(file);
       doPostMessage(id, {type: "open", payload: {osr}});
       break;
     }


### PR DESCRIPTION
This provides the configurable option to create N workers when creating the `OpenSlide` instance. This seems to help in cases where we have many `readRegion` calls happening concurrently. The trade-off is that it triggers N network requests for `worker.js`, `lib.js`, and `lib.wasm`, although in local testing it appears that the subsequent calls re-use the initial request's response data.