### PR TITLE
Always return RGBA from readRegion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ async function drawSlide(slideFile: File, mpp: number) {
    const bestLevel = await slide.getBestLevelForDownsample(downsample);
    const [levelWidth, levelHeight] = await slide.getLevelDimensions(bestLevel);
 
-   const region = await slide.readRegion(0, 0, bestLevel, levelWidth, levelHeight, true);
+   const region = await slide.readRegion(0, 0, bestLevel, levelWidth, levelHeight);
    const imageData = new ImageData(region, levelWidth, levelHeight);
 
    // Resize the image tile data to the desired width and height

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -67,7 +67,7 @@
             const x = i * regionWidth;
             const y = j * regionHeight;
             regionPromises.push(
-              slide.readRegion(x, y, bestLevel, regionLevelWidth, regionLevelHeight, true)
+              slide.readRegion(x, y, bestLevel, regionLevelWidth, regionLevelHeight)
             );
           }
         }

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -290,12 +290,11 @@ class OpenSlideImage {
    * @param level - The level of the image to read from.
    * @param width - The width of the region to read.
    * @param height - The height of the region to read.
-   * @param readRgba - Whether to read the region as RGBA (default: false).
-   * @returns A promise that resolves to a Uint8ClampedArray containing the pixel data.
+   * @returns A promise that resolves to a Uint8ClampedArray containing the pixel data in RGBA format.
    */
-  async readRegion(x: number, y: number, level: number, width: number, height: number, readRgba: boolean = false): Promise<Uint8ClampedArray> {
+  async readRegion(x: number, y: number, level: number, width: number, height: number): Promise<Uint8ClampedArray> {
     const { osr, worker } = this.getHandle();
-    const response = await worker.sendCommand({ type: "readRegion", payload: { osr, x, y, level, width, height, readRgba } });
+    const response = await worker.sendCommand({ type: "readRegion", payload: { osr, x, y, level, width, height } });
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }

--- a/openslide-wasm/src/types.ts
+++ b/openslide-wasm/src/types.ts
@@ -10,7 +10,7 @@ export type WorkerCommandBase =
   | {type: "getLevelDimensions", payload: {osr: OpenSlideT, level: number}}
   | {type: "getLevelDownsample", payload: {osr: OpenSlideT, level: number}}
   | {type: "getBestLevelForDownsample", payload: {osr: OpenSlideT, downsample: number}}
-  | {type: "readRegion", payload: {osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number, readRgba?: boolean}}
+  | {type: "readRegion", payload: {osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number}}
 export type WorkerCommand = WorkerCommandBase & {id: string};
 
 export type WorkerResponseBase =

--- a/openslide-wasm/src/worker.ts
+++ b/openslide-wasm/src/worker.ts
@@ -105,7 +105,7 @@ class OpenSlideApi {
     return level;
   }
 
-  async readRegion(osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number, readRgba: boolean = false) {
+  async readRegion(osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number) {
     // We malloc memory to pack all values into a single chunk of memory
     const args = this.lib._malloc(40);
     this.lib.HEAP64[args / 8] = BigInt(x); // int64_t x (8 bytes)
@@ -114,7 +114,7 @@ class OpenSlideApi {
     this.lib.HEAP32[args / 4 + 5] = 0; // Padding (4 bytes, required for alignment)
     this.lib.HEAP64[args / 8 + 3] = BigInt(width); // int64_t w (8 bytes)
     this.lib.HEAP64[args / 8 + 4] = BigInt(height); // int64_t h (8 bytes)
-    this.lib.HEAP32[args / 4 + 10] = readRgba ? 1 : 0; // int32_t read_rgba (4 bytes)
+    this.lib.HEAP32[args / 4 + 10] = 1; // int32_t read_rgba always 1 (4 bytes)
 
     const data = await this._readRegionAsync(osr, args);
     this.lib._free(args);
@@ -279,8 +279,8 @@ async function handleMessage(
       break;
     }
     case "readRegion": {
-      const {osr, x, y, level, width, height, readRgba} = data.payload;
-      const regionData = await api.readRegion(osr, x, y, level, width, height, readRgba);
+      const {osr, x, y, level, width, height} = data.payload;
+      const regionData = await api.readRegion(osr, x, y, level, width, height);
       doPostMessage(id, {type: "readRegion", payload: {data: regionData}});
       break;
     }


### PR DESCRIPTION
Removes the option to not return in RGBA order (which would result in BGRA order) since that is not likely to be used.

For posterity, we considered just changing the default to `true`, but we also don't see a real use case for wanting BGRA order, so for simplicity we are removing that option.

In the future we can clean up the `openslide-api.c` file, but that's not a big deal at this point given it's not in the public facing API.