### PR TITLE
Implement ability to abort readRegion calls

### DIFF
--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -22,6 +22,7 @@
       const remoteUrlInput = document.getElementById("remoteUrl");
       const loadRemoteButton = document.getElementById("loadRemote");
       const clearButton = document.getElementById("clear");
+      const abortButton = document.getElementById("abort");
       const canvasContainer = document.getElementById("canvas-container");
 
       const handleSlide = async (slide) => {
@@ -62,36 +63,74 @@
         const regionTargetHeight = Math.floor(targetHeight / numPartitions);
 
         const regionPromises = [];
+        const regionControllers = [];
         for (let j = 0; j < numPartitions; j++) {
           for (let i = 0; i < numPartitions; i++) {
             const x = i * regionWidth;
             const y = j * regionHeight;
-            regionPromises.push(
-              slide.readRegion(x, y, bestLevel, regionLevelWidth, regionLevelHeight)
-            );
+            const regionController = new AbortController();
+            regionControllers.push(regionController);
+            const opts = {
+              signal: regionController.signal,
+            };
+            const fn = async () => {
+              try {
+                const region = await slide.readRegion(x, y, bestLevel, regionLevelWidth, regionLevelHeight, opts);
+                return region;
+              } catch (err) {
+                console.error("Error reading region", err);
+                return null;
+              }
+            }
+            regionPromises.push(fn());
           }
         }
+        abortButton.onclick = () => {
+          regionControllers.forEach((controller) => {
+            console.log('aborting');
+            controller.abort("Abort button clicked");
+          });
+        };
         console.time('readRegion');
         const allRegions = await Promise.all(regionPromises);
         console.timeEnd('readRegion');
-        allRegions.forEach(async (region, index) => {
-          const imageData = new ImageData(region, regionLevelWidth, regionLevelHeight);
-
-          // Resize the image tile data to the desired width and height
-          const bitmap = await createImageBitmap(imageData, {
-            resizeWidth: regionTargetWidth,
-            resizeHeight: regionTargetHeight,
-          });
-
+        for (const region of allRegions) {
           const canvas = document.createElement("canvas");
           const ctx2d = canvas.getContext("2d");
           canvas.style.border = "1px solid black";
           canvas.width = regionTargetWidth;
           canvas.height = regionTargetHeight;
-          ctx2d.drawImage(bitmap, 0, 0);
 
+          if (region) {
+            const imageData = new ImageData(region, regionLevelWidth, regionLevelHeight);
+
+            // Resize the image tile data to the desired width and height
+            const bitmap = await createImageBitmap(imageData, {
+              resizeWidth: regionTargetWidth,
+              resizeHeight: regionTargetHeight,
+            });
+
+            ctx2d.drawImage(bitmap, 0, 0);
+          } else {
+            // Draw a transparent black box when no image data is available
+            ctx2d.fillStyle = "rgba(0, 0, 0, 0.8)";
+            ctx2d.fillRect(0, 0, regionTargetWidth, regionTargetHeight);
+
+            // Add warning symbol (exclamation mark)
+            ctx2d.fillStyle = "yellow";
+            ctx2d.beginPath();
+            ctx2d.arc(regionTargetWidth / 2, regionTargetHeight / 2 - 15, 15, 0, Math.PI * 2);
+            ctx2d.fill();
+
+            // Draw exclamation mark
+            ctx2d.fillStyle = "black";
+            ctx2d.font = "bold 20px Arial";
+            ctx2d.textAlign = "center";
+            ctx2d.textBaseline = "middle";
+            ctx2d.fillText("!", regionTargetWidth / 2, regionTargetHeight / 2 - 15);
+          }
           canvasContainer.appendChild(canvas);
-        });
+        };
       }
 
       // On file input change, load the file and display it
@@ -135,6 +174,7 @@
     </div>
     <div>
       <button id="clear">Clear</button>
+      <button id="abort">Abort</button>
     </div>
     <div id="canvas-container" style="display: inline-grid; grid-template-columns: repeat(2, auto);">
     </div>

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -67,7 +67,7 @@ class OpenSlideWorker {
         this.worker.postMessage({ type: "abort", id });
         signal.removeEventListener("abort", abortHandler!);
         // TODO: Upgrade TypeScript to >5 and see if this fixes the issue here.
-        const reason = (signal as any).reason as string;
+        const reason = (signal as any as { reason: string }).reason;
         reject(createAbortError(reason));
       };
       if (signal && abortHandler) {

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -3,6 +3,8 @@ import { WorkerCommandBase, WorkerResponse, OpenSlideT } from "./types";
 type PromiseFns = {
   resolve: (value: WorkerResponse) => void;
   reject: (reason: Error) => void;
+  signal?: AbortSignal;
+  abortHandler?: (event: Event) => void;
 }
 
 function randomString(length: number = 10) {
@@ -11,6 +13,14 @@ function randomString(length: number = 10) {
     randomName += String.fromCharCode(Math.floor(Math.random() * 26) + 97);
   }
   return randomName;
+}
+
+
+export interface ReadRegionOptions {
+  signal?: AbortSignal;
+}
+interface CommandOptions {
+  signal?: AbortSignal;
 }
 
 class OpenSlideWorker {
@@ -29,6 +39,10 @@ class OpenSlideWorker {
         return;
       }
       this.promiseFns.delete(id);
+      const { signal, abortHandler } = promiseFn;
+      if (signal && abortHandler) {
+        signal.removeEventListener("abort", abortHandler);
+      }
       const { resolve, reject } = promiseFn;
       if (data.type === "error") {
         reject(new Error(data.payload.message));
@@ -43,14 +57,25 @@ class OpenSlideWorker {
     return this.promiseFns.size;
   }
 
-  sendCommand(command: WorkerCommandBase): Promise<WorkerResponse> {
+  sendCommand(command: WorkerCommandBase, opts?: CommandOptions): Promise<WorkerResponse> {
     const id = randomString(16);
+    const signal = opts?.signal;
     return new Promise<WorkerResponse>((resolve, reject) => {
       this.worker.postMessage({ ...command, id });
-      this.promiseFns.set(id, { resolve, reject });
+      const abortHandler = signal === undefined ? undefined : (event: Event) => {
+        this.promiseFns.delete(id);
+        this.worker.postMessage({ type: "abort", id });
+        signal.removeEventListener("abort", abortHandler!);
+        // TODO: Upgrade TypeScript to >5 and see if this fixes the issue here.
+        const reason = (signal as any).reason as string;
+        reject(createAbortError(reason));
+      };
+      if (signal && abortHandler) {
+        signal.addEventListener("abort", abortHandler);
+      }
+      this.promiseFns.set(id, { resolve, reject, signal, abortHandler });
     });
   }
-
 }
 
 export interface OpenSlideOptions {
@@ -136,15 +161,27 @@ function ensureFileOrUrl(file: File | URL | string): File | URL {
 
 async function fetchFileFromUrl(url: URL) {
   const filename = url.pathname.split("/").pop() || "filename";
-  console.log("Fetching file from URL:", url.toString());
   const response = await fetch(url.toString());
-  console.log("Response status:", response.status);
   const blob = await response.blob();
-  console.log("Blob size:", blob.size);
   const file = new File([blob], filename, { type: blob.type });
   return file;
 }
 
+class AbortError extends Error {
+  constructor(message = "Aborted") {
+    super(message);
+    this.name = "AbortError";
+  }
+}
+
+function createAbortError(reason: string = "Aborted") {
+  if (typeof DOMException === "function") {
+    return new DOMException(reason, "AbortError");
+  }
+
+  // Custom fallback for environments without DOMException
+  return new AbortError(reason);
+}
 
 interface OpenSlideHandle {
   osr: OpenSlideT;
@@ -292,9 +329,9 @@ class OpenSlideImage {
    * @param height - The height of the region to read.
    * @returns A promise that resolves to a Uint8ClampedArray containing the pixel data in RGBA format.
    */
-  async readRegion(x: number, y: number, level: number, width: number, height: number): Promise<Uint8ClampedArray> {
+  async readRegion(x: number, y: number, level: number, width: number, height: number, options?: ReadRegionOptions): Promise<Uint8ClampedArray> {
     const { osr, worker } = this.getHandle();
-    const response = await worker.sendCommand({ type: "readRegion", payload: { osr, x, y, level, width, height } });
+    const response = await worker.sendCommand({ type: "readRegion", payload: { osr, x, y, level, width, height } }, options);
     if (response.type === "error") {
       throw new Error(response.payload.message);
     }

--- a/openslide-wasm/src/types.ts
+++ b/openslide-wasm/src/types.ts
@@ -11,6 +11,7 @@ export type WorkerCommandBase =
   | {type: "getLevelDownsample", payload: {osr: OpenSlideT, level: number}}
   | {type: "getBestLevelForDownsample", payload: {osr: OpenSlideT, downsample: number}}
   | {type: "readRegion", payload: {osr: OpenSlideT, x: number, y: number, level: number, width: number, height: number}}
+  | {type: "abort"}
 export type WorkerCommand = WorkerCommandBase & {id: string};
 
 export type WorkerResponseBase =

--- a/openslide-wasm/src/worker.ts
+++ b/openslide-wasm/src/worker.ts
@@ -33,6 +33,46 @@ function randomString(length: number = 10) {
 }
 
 
+interface QueueJob {
+  id: string;
+  fn: () => Promise<void>;
+}
+class Queue {
+  private _queue: QueueJob[] = [];
+  private _runningCount = 0;
+
+  constructor(private _concurrency = 1) {}
+
+  async run() {
+    // Start as many tasks as we can, up to concurrency limit
+    while (this._runningCount < this._concurrency && this._queue.length > 0) {
+      const job = this._queue.shift();
+      if (job) {
+        this._runningCount++;
+        // Execute the task and decrement counter when done
+        // Use finally to ensure counter decrements even if task fails
+        job.fn().finally(() => {
+          this._runningCount--;
+          // Try to run more tasks when this one completes
+          this.run();
+        });
+      }
+    }
+  }
+
+  add(job: QueueJob) {
+    this._queue.push(job);
+    this.run();
+  }
+
+  abort(id: string) {
+    this._queue = this._queue.filter(job => job.id !== id);
+  }
+}
+
+const _READ_REGION_CONCURRENCY = 4;
+const _READ_REGION_QUEUE = new Queue(_READ_REGION_CONCURRENCY);
+
 class OpenSlideApi {
   private _getPropertyNamesAsync: (osr: OpenSlideT) => Promise<Pointer>;
   private _getPropertyValueAsync: (osr: OpenSlideT, name: string) => Promise<Pointer>;
@@ -189,7 +229,6 @@ class OpenSlideApi {
 let api: OpenSlideApi | undefined = undefined;
 
 
-
 function doPostMessage(id: string, message: WorkerResponseBase) {
   self.postMessage({id, ...message});
 }
@@ -280,13 +319,33 @@ async function handleMessage(
     }
     case "readRegion": {
       const {osr, x, y, level, width, height} = data.payload;
-      const regionData = await api.readRegion(osr, x, y, level, width, height);
-      doPostMessage(id, {type: "readRegion", payload: {data: regionData}});
+      _READ_REGION_QUEUE.add({
+        id,
+        fn: async () => {
+          // If we don't add some minor wait here, we don't give the worker
+          // a chance to process other messages. This is especially important
+          // for the abort messages, which might include an abort of this readRegion
+          // call.
+          // Even though `api.readRegion` is async, it doesn't seem to yield
+          // the event loop.
+          await timeout(0);
+          const regionData = await api.readRegion(osr, x, y, level, width, height);
+          doPostMessage(id, {type: "readRegion", payload: {data: regionData}});
+        },
+      });
+      break;
+    }
+    case "abort": {
+      _READ_REGION_QUEUE.abort(id);
       break;
     }
     default:
       exhaustiveCheck(dataType);
   }
+}
+
+function timeout(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function exhaustiveCheck(x: never): never {


### PR DESCRIPTION
This will be helpful when working with tile fetching in a slide viewer where we can abort fetching of tiles that are no longer in view.

In reality it will only "abort" the `readRegion` call if we haven't yet passed into the C layer. When there a lot of concurrent `readRegion` calls (e.g. in a slide viewer, or in the example HTML file in this repo when increasing the number of partitions) this actually does abort a number of calls to `api.readRegion`.

### Usage

```typescript
const controller = new AbortController();
const region = await slide.readRegion(x, y, level, w, h, {
  signal: controller.signal;
});
```
And then somewhere else:
```typescript
controller.abort("Region not needed");
```
At which point `slide.readRegion` would throw an `AbortError` with message `"Region not needed"`.