### PR TITLE
Bump to 2.2.1

### DIFF
--- a/openslide-wasm/package.json
+++ b/openslide-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conflux-xyz/openslide-wasm",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/openslide.js",


### PR DESCRIPTION
Pushed to 2.2.0 but then realized we might not have correctly built first, so pushed to 2.2.1 to ensure update.