### PR TITLE
Add ability to provide slide MPP in example file

### DIFF
--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -27,6 +27,8 @@
       const fileInput = document.getElementById("file");
       const remoteUrlInput = document.getElementById("remoteUrl");
       const loadRemoteButton = document.getElementById("loadRemote");
+      const overrideSlideMppCheckbox = document.getElementById("override-slide-mpp");
+      const slideMppInput = document.getElementById("slide-mpp");
       const clearButton = document.getElementById("clear");
       const abortButton = document.getElementById("abort");
       const canvasContainer = document.getElementById("canvas-container");
@@ -127,6 +129,15 @@
         return clamped;
       };
 
+      const getSlideMpp = async (slide) => {
+        const slideMppStr = await slide.getPropertyValue("openslide.mpp-x");
+        if (!slideMppStr) {
+          console.error("No MPP property found");
+          return null;
+        }
+        return parseFloat(slideMppStr);
+      }
+
       const handleSlide = async (slide) => {
         clearButton.onclick = async () => {
           console.log('closing...');
@@ -150,13 +161,15 @@
         const iccTransform = getIccTransform(iccProfile);
         const applyIccProfile = applyIccProfileCheckbox.checked;
 
-        const slideMppStr = await slide.getPropertyValue("openslide.mpp-x");
-        if (!slideMppStr) {
-          console.error("No MPP property found");
+        const slideMppFromSlide = await getSlideMpp(slide);
+        const slideMpp = overrideSlideMppCheckbox.checked
+          ? parseFloat(slideMppInput.value)
+          : slideMppFromSlide;
+        if (!slideMpp) {
+          console.error("No MPP found");
           return;
         }
-        const slideMpp = parseFloat(slideMppStr);
-        console.log("Slide MPP", slideMpp);
+        console.log("Slide MPP", slideMpp, "from slide", slideMppFromSlide);
 
         console.log("Level count", await slide.getLevelCount())
         const mpp = parseFloat(mppInput.value);
@@ -296,6 +309,11 @@
       <button id="loadRemote">Load Remote</button>
       <input type="checkbox" id="downloadRemote" />
       <label for="downloadRemote">Download Remote</label>
+    </div>
+    <div style="margin: 10px 0;">
+      <input type="checkbox" id="override-slide-mpp" />
+      <label for="override-slide-mpp">Override Slide MPP</label>
+      <input type="number" id="slide-mpp" placeholder="MPP" value="0.5" step="0.01"/>
     </div>
     <div style="margin: 10px 0;">
       <label for="mpp">MPP</label>


### PR DESCRIPTION
Some files have no MPP or an erroneous MPP (e.g. `1000`). This allows overriding the MPP in the example HTML file.