### PR TITLE
Add support for multi-file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,59 @@ For this to work:
 Access-Control-Expose-Headers: Accept-Ranges, Content-Encoding, Content-Length
 ```
 
-### File Formats
+### Multi-File Formats
 
-At this point most, but not all, WSI file formats supported by the OpenSlide C library are also supported by OpenSlideWASM. We will strive to support all the same formats that OpenSlide C supports.
+While many WSI file formats are single-file, and therefore straightforward to use in a browser context, some format are multi-file, such as [DICOM](https://openslide.org/formats/dicom/), [MIRAX](https://openslide.org/formats/mirax/), and [Hamamatsu VMS and VMU](https://openslide.org/formats/hamamatsu/).
 
-If you find a format that does not work, please file an issue, and, even better, submit a pull request!
+Support for these formats is provided by using the `File[]` or `FileEntry[]` types to `openSlide.open(...)`:
+
+```typescript
+interface FileEntry {
+   file: File;
+   path: string;
+}
+```
+
+This allows you to provide multiple files and allows you to specify the context of those files within a directory structure, if necessary.
+
+The first element of the array is the one that will be passed to OpenSlide as the file to open.
+
+Below are a few examples:
+```typescript
+// MIRAX requires a file `{NAME}.mrxs` file with a corresponding `{NAME}/` sibling directory.
+function getMiraxFileEntries(files: File[]): FileEntry[] {
+   const miraxFile = files.find(file => file.name.toLowerCase().endsWith(".mrxs"));
+   if (!miraxFile) {
+      throw new Error("No .mrxs file found in the provided files");
+   }
+   // Create the directory structure and ensure .mrxs file is first
+   const miraxFileEntry = {file: miraxFile, path: miraxFile.name};
+   const dirname = miraxFile.name.slice(0, -5); // Remove the .mrxs extension for the directory name
+   const otherFiles = files.filter(file => file !== miraxFile);
+   const otherFileEntries = otherFiles.map(file => ({file, path: `${dirname}/${file.name}`}))
+   return [miraxFileEntry, ...otherFileEntries];
+}
+
+// Hamamatsu VMS requires reading in the `.vms` file but needs all other files as well.
+function getHamamatsuVmsFiles(files: File[]): File[] {
+   const vmsFile = files.find(file => file.name.toLowerCase().endsWith(".vms"));
+   if (!vmsFile) {
+      throw new Error("No .vms file found in the provided files");
+   }
+   const otherFiles = files.filter(file => file !== vmsFile);
+   return [vmsFile, ...otherFiles];
+}
+
+// For DICOM, OpenSlide doesn't care which file is passed in, as long as all files are present
+function getDicomFiles(files: File[]): File[] {
+   // Basically a no-op
+   return files;
+}
+```
+
+
+### Other File Formats
+
+We strive to support all WSI file formats that are supported by the OpenSlide C library.
+
+If you find a format that works with the OpenSlide C library but not with OpenSlideWASM, please file an issue, and, even better, submit a pull request!

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Access-Control-Expose-Headers: Accept-Ranges, Content-Encoding, Content-Length
 
 ### Multi-File Formats
 
-While many WSI file formats are single-file, and therefore straightforward to use in a browser context, some format are multi-file, such as [DICOM](https://openslide.org/formats/dicom/), [MIRAX](https://openslide.org/formats/mirax/), and [Hamamatsu VMS and VMU](https://openslide.org/formats/hamamatsu/).
+While many WSI file formats are single-file, and therefore straightforward to use in a browser context, some formats are multi-file, such as [DICOM](https://openslide.org/formats/dicom/), [MIRAX](https://openslide.org/formats/mirax/), and [Hamamatsu VMS and VMU](https://openslide.org/formats/hamamatsu/).
 
 Support for these formats is provided by using the `File[]` or `FileEntry[]` types to `openSlide.open(...)`:
 

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Openslide Test</title>
     <script language="javascript" type="module">
-      import OpenSlide from "/openslide-wasm/dist/openslide.js";
+      import OpenSlide, { fileEntriesFromFiles, applyAlpha } from "/openslide-wasm/dist/openslide.js";
       import { instantiate, INTENT_PERCEPTUAL, TYPE_RGB_8, TYPE_RGBA_8 } from "/examples/canvas/lcms/lcms.js";
 
       async function initialize() {
@@ -81,40 +81,11 @@
         return transform;
       }
 
-      // Convert RGBA to RGB with Alpha = 255
-      // Ref: https://openslide.org/docs/premultiplied-argb/
-      const applyAlphaInPlace = (imageData) => {
-
-        // Function to convert RGBA data to RGB data
-        if (!imageData || imageData.length === 0) {
-          console.warn("Empty image data provided to convertToRgb");
-          return null;
-        }
-
-        for (let i = 0; i < imageData.length; i += 4) {
-          const a = imageData[i + 3]; // Alpha channel
-          if (a === 0) {
-            // white (or could use openslide.background-color if available)
-            imageData[i] = imageData[i + 1] = imageData[i + 2] = 255;
-            imageData[i + 3] = 255; // Set alpha to 255
-          } else if (a === 255) {
-            // fully opaque, no need to premultiply => no-op
-          } else {
-            // Premultiply RGB values by alpha
-            const alpha = a / 255; // Normalize alpha to [0, 1]
-            imageData[i] = Math.round(imageData[i] * alpha);
-            imageData[i + 1] = Math.round(imageData[i + 1] * alpha);
-            imageData[i + 2] = Math.round(imageData[i + 2] * alpha);
-            imageData[i + 3] = 255; // Set alpha to 255
-          }
-        }
-      }
-
       const doTransform = (iccTransform, region) => {
         if (iccTransform === null) {
           return region;
         }
-        applyAlphaInPlace(region);
+        applyAlpha(region);
 
         const imageRegionData = lcms.cmsDoTransform(iccTransform, region, region.length / 4);
         // `imageRegionData` is a Uint8Array, we need to convert it to Uint8ClampedArray
@@ -269,14 +240,49 @@
         }
       }
 
+      function getMiraxFileEntries(files) {
+        const miraxFile = files.find(file => file.name.toLowerCase().endsWith(".mrxs"));
+        if (!miraxFile) {
+            throw new Error("No .mrxs file found in the provided files");
+        }
+        // Create the directory structure and ensure .mrxs file is first
+        const otherFiles = files.filter(file => file !== miraxFile);
+        const miraxFileEntry = {file: miraxFile, path: miraxFile.name};
+        const dirname = miraxFile.name.slice(0, -5); // Remove the .mrxs extension for the directory name
+        const otherFileEntries = otherFiles.map(file => ({file: file, path: `${dirname}/${file.name}`}))
+        return [miraxFileEntry, ...otherFileEntries];
+      }
+
+      function getVmsFileEntries(files) {
+        const vmsFile = files.find(file => file.name.toLowerCase().endsWith(".vms"));
+        if (!vmsFile) {
+          throw new Error("No .vms file found in the provided files");
+        }
+        const otherFiles = files.filter(file => file !== vmsFile);
+        const reorderedFiles = [vmsFile, ...otherFiles];
+        return fileEntriesFromFiles(reorderedFiles);
+      }
+
+      function getFileEntries(files) {
+        const isMrxs = files.some(file => file.name.toLowerCase().endsWith(".mrxs"));
+        if (isMrxs) {
+          return getMiraxFileEntries(files);
+        }
+        const isVms = files.some(file => file.name.toLowerCase().endsWith(".vms"));
+        if (isVms) {
+          return getVmsFileEntries(files);
+        }
+        return files.map((file) => ({file, path: file.name}));
+      }
+
       // On file input change, load the file and display it
       fileInput.addEventListener("change", async (e) => {
         clearButton.onclick = null;
-        const file = e.target.files[0];
-        if (!file) return;
-        console.log('file', file);
+        const files = getFileEntries(Array.from(e.target.files));
+        if (!files) return;
+        console.log('files', files);
         try {
-          const slide = await window.openslide.open(file);
+          const slide = await window.openslide.open(files);
           await handleSlide(slide);
         } catch (e) {
           console.error("Error handling slide!", e);
@@ -302,7 +308,7 @@
   </head>
   <body>
     <div style="margin: 10px 0;">
-      <input type="file" id="file" name="SLIDE" />
+      <input type="file" id="file" name="SLIDE" multiple />
     </div>
     <div style="margin: 10px 0;">
       <input type="text" id="remoteUrl" placeholder="Remote URL" value="https://d3bzvr1k8ur14a.cloudfront.net/openslide-wasm/TCGA-LL-A7SZ-01Z-00-DX1.4DAF6421-6A1D-41C8-BFD6-859FE10CB8CC.svs" />

--- a/openslide-wasm/package.json
+++ b/openslide-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conflux-xyz/openslide-wasm",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/openslide.js",

--- a/openslide-wasm/src/openslide.ts
+++ b/openslide-wasm/src/openslide.ts
@@ -1,4 +1,4 @@
-import { WorkerCommandBase, WorkerResponse, OpenSlideT } from "./types";
+import { WorkerCommandBase, WorkerResponse, OpenSlideT, FileEntry } from "./types";
 
 type PromiseFns = {
   resolve: (value: WorkerResponse) => void;
@@ -113,7 +113,23 @@ export default class OpenSlide {
     return;
   }
 
-  async open(file: File | URL | string, downloadToLocal: boolean = false): Promise<OpenSlideImage> {
+  /**
+   * Open a WSI with OpenSlide.
+   * In the case of multi-file formats like DICOM, MIRAX, and Hamamatsu-VMS, use the `FileEntry[]` array
+   * where each entry contains a `File` and its corresponding path.
+   * The _first_ file in the array will be used to open the slide.
+   * 
+   * @param file A File, File array, FileEntry array, URL, or string representing the file path or URL to open.
+   * @param downloadToLocal Whether to download the file to local storage (only applicable for URLs).
+   * @returns A promise that resolves to an OpenSlideImage instance.
+   */
+  async open(file: File | File[] | FileEntry[] | URL | string, downloadToLocal: boolean = false): Promise<OpenSlideImage> {
+    if (Array.isArray(file) && file.length === 0) {
+      throw new Error("File array is empty");
+    }
+    if (isFileEntryArray(file)) {
+      validateFileEntryArray(file);
+    }
     const fileOrUrl = ensureFileOrUrl(file);
     if (fileOrUrl instanceof URL && downloadToLocal) {
       const file = await fetchFileFromUrl(fileOrUrl);
@@ -137,8 +153,47 @@ export default class OpenSlide {
   }
 }
 
-function ensureFileOrUrl(file: File | URL | string): File | URL {
-  if (file instanceof File || file instanceof URL) {
+function isFileEntryArray(file: File | File[] | FileEntry[] | URL | string): file is FileEntry[] {
+  return Array.isArray(file) && !file.some((f) => !isFileEntry(f));
+}
+
+function isFileEntry(file: File | FileEntry): file is FileEntry {
+  return (file as FileEntry).file !== undefined && (file as FileEntry).path !== undefined;
+}
+
+function validateFileEntryArray(fileEntries: FileEntry[]) {
+  for (const entry of fileEntries) {
+    if (!isValidDescendantFilePath(entry.path)) {
+      throw new Error(`Invalid file path: ${entry.path}`);
+    }
+  }
+}
+
+// Validate that the path is a relative path (not absolute),
+// doesn't try to navigate to parent directories, and uses forward slashes
+function isValidDescendantFilePath(path: string): boolean {
+  if (path === "") {
+    return false;
+  }
+  // Check if the path is absolute
+  if (path.startsWith("/") || // Unix-like absolute path
+      /^[A-Za-z]:[\\\/]/.test(path) || // Windows absolute path (e.g., C:\ or C:/)
+      path.startsWith('\\\\')) { // Windows UNC path
+    return false;
+  }
+  
+  // Check for backslashes (disallow them)
+  if (path.includes('\\')) {
+    return false;
+  }
+  
+  // Check for path traversal attempts using ..
+  const parts = path.split('/');
+  return !parts.includes('..') && !parts.includes('.');
+}
+
+function ensureFileOrUrl(file: File | File[] | FileEntry[] | URL | string): File | File[] | FileEntry[] | URL {
+  if (Array.isArray(file) || file instanceof File || file instanceof URL) {
     return file;
   }
   if (file.startsWith("http://") || file.startsWith("https://")) {
@@ -360,3 +415,60 @@ class OpenSlideImage {
 }
 
 export type { OpenSlideImage };
+export type { FileEntry };
+
+/**
+ * Convert an array of File objects to an array of FileEntry objects.
+ * 
+ * @param files An array of File objects.
+ * @returns An array of FileEntry objects, each containing the file and its path.
+ */
+export function fileEntriesFromFiles(files: File[]): FileEntry[] {
+  return files.map((file) => ({file, path: file.name}));
+}
+
+
+interface ApplyAlphaOptions {
+  backgroundColor?: [number, number, number];
+  inPlace?: boolean;
+}
+/**
+ * Apply alpha compositing to the image data, following the
+ * idiosyncrasies noted in the OpenSlide documentation.
+ * By default the operation is performed in place.
+ * Ref: https://openslide.org/docs/premultiplied-argb/
+ * 
+ * @param imageData The image data in RGBA format as a Uint8ClampedArray.
+ * @param options Options for applying alpha compositing.
+ * @param options.backgroundColor The background color to use for fully transparent pixels (default: [255, 255, 255]).
+ * @param options.inPlace Whether to modify the imageData in place (default: true).
+ */
+export function applyAlpha(
+  imageData: Uint8ClampedArray,
+  options?: ApplyAlphaOptions,
+) {
+  const backgroundColor = options?.backgroundColor || [255, 255, 255];
+  const inPlace = options?.inPlace ?? true;
+  const returnImageData = inPlace ? imageData : new Uint8ClampedArray(imageData);
+
+  for (let i = 0; i < returnImageData.length; i += 4) {
+    const a = returnImageData[i + 3];
+    if (a === 0) {
+      // white (or could use openslide.background-color if available)
+      returnImageData[i] = backgroundColor[0];
+      returnImageData[i + 1] = backgroundColor[1];
+      returnImageData[i + 2] = backgroundColor[2];
+      returnImageData[i + 3] = 255; // Set alpha to 255
+    } else if (a === 255) {
+      // fully opaque, no need to premultiply => no-op
+    } else {
+      // Premultiply RGB values by alpha
+      const alpha = a / 255; // Normalize alpha to [0, 1]
+      returnImageData[i] = Math.round(returnImageData[i] * alpha);
+      returnImageData[i + 1] = Math.round(returnImageData[i + 1] * alpha);
+      returnImageData[i + 2] = Math.round(returnImageData[i + 2] * alpha);
+      returnImageData[i + 3] = 255; // Set alpha to 255
+    }
+  }
+  return returnImageData;
+}

--- a/openslide-wasm/src/types.ts
+++ b/openslide-wasm/src/types.ts
@@ -1,8 +1,13 @@
 export type OpenSlideT = number;
 
+export interface FileEntry {
+  path: string;
+  file: File;
+}
+
 export type WorkerCommandBase =
   | {type: "init"}
-  | {type: "open", payload: {file: File | string}}
+  | {type: "open", payload: {file: File | File[] | FileEntry[] | string}}
   | {type: "close", payload: {osr: OpenSlideT}}
   | {type: "getPropertyNames", payload: {osr: OpenSlideT}}
   | {type: "getPropertyValue", payload: {osr: OpenSlideT, name: string}}

--- a/openslide-wasm/src/worker.ts
+++ b/openslide-wasm/src/worker.ts
@@ -1,5 +1,5 @@
 /// <reference types="emscripten" />
-import { WorkerCommand, WorkerResponseBase, OpenSlideT } from "./types";
+import { WorkerCommand, WorkerResponseBase, OpenSlideT, FileEntry } from "./types";
 import createModule_ from "./lib.js";
 
 const createModule: EmscriptenModuleFactory<OpenSlideEmscriptenModule> = createModule_;
@@ -203,9 +203,9 @@ class OpenSlideApi {
     return profile;
   }
 
-  async open(file: File | string) {
-    const fileOrUrl = file instanceof File ? file : new URL(file);
-    const {filename, mountDir} = await this._open_file(fileOrUrl);
+  async open(file: File | File[] | FileEntry[] | string) {
+    const fileOrUrl = (Array.isArray(file) || file instanceof File) ? file : new URL(file);
+    const {filename, mountDir} = await this._openFile(fileOrUrl);
     const filepath = mountDir ? `${mountDir}/${filename}` : filename;
     const osr = await this._openSlideAsync(filepath);
     if (osr === 0) {
@@ -219,28 +219,56 @@ class OpenSlideApi {
     return osr;
   }
 
-  async _open_file(file: File | URL) {
+  async _openFile(file: File | File[] | FileEntry[] | URL) {
     if (file instanceof URL) {
       return {
         filename: "remote",
-        mountDir: this._mount_url(file),
+        mountDir: this._mountUrl(file),
       };
     } else {
+      const files = fileEntriesFromFilesOrFileEntries(file);
       return {
-        filename: file.name,
-        mountDir: this._mount_file(file),
+        filename: files[0].path,
+        mountDir: this._mountFiles(files),
       };
     }
   }
 
-  _mount_file(file: File) {
+  _mountFiles(files: FileEntry[]) {
     const dirname = `${_TMP_PREFIX}${randomString()}`;
     this.lib.FS.mkdir(dirname);
-    this.lib.FS.mount(this.lib.WORKERFS, { files: [file] }, dirname)
+    const mountNode = this.lib.FS.mount(this.lib.WORKERFS, {}, dirname) as FS.FSNode;
+
+    const nodes = new Map<string, FS.FSNode>();
+    nodes.set(dirname, mountNode);
+    const ensureParent = (path: string): FS.FSNode => {
+      const parts = path.split("/");
+      let currentNode: FS.FSNode = mountNode;
+      for (let i = 0; i < parts.length - 1; i++) {
+        const partDirname = parts.slice(0, i + 1).join("/");
+        const part = parts[i];
+        if (!nodes.has(partDirname)) {
+          // Create the directory if it doesn't exist
+          // @ts-expect-error ts(2339)
+          const newNode = this.lib.WORKERFS.createNode(currentNode, part, this.lib.WORKERFS.DIR_MODE, 0) as FS.FSNode;
+          nodes.set(partDirname, newNode);
+        }
+        currentNode = nodes.get(partDirname)!;
+      }
+      return currentNode;
+    }
+    files.forEach((fileEntry) => {
+      const {file, path} = fileEntry;
+      const parentDir = ensureParent(path);
+      const fileName = path.split("/").pop()!;
+      const lastModifiedDate = file.lastModified ? new Date(file.lastModified) : undefined;
+      // @ts-expect-error ts(2339)
+      this.lib.WORKERFS.createNode(parentDir, fileName, this.lib.WORKERFS.FILE_MODE, 0, file, lastModifiedDate);
+    });
     return dirname;
   }
 
-  _mount_url(url: URL) {
+  _mountUrl(url: URL) {
     const dirname = `${_TMP_PREFIX}${randomString()}`;
     this.lib.FS.mkdir(dirname);
     this.lib.FS.mount(this.lib.MEMFS, {}, dirname)
@@ -288,6 +316,7 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
   try {
     await handleMessage(api, data);
   } catch (error) {
+    console.error("Error handling message:", error);
     doPostMessage(id, {type: "error", payload: {message: (error as Error).message}});
   }
 }
@@ -389,4 +418,21 @@ function timeout(ms: number): Promise<void> {
 
 function exhaustiveCheck(x: never): never {
   throw new Error(`Unexpected object: ${x}`);
+}
+
+
+function fileEntriesFromFilesOrFileEntries(file: File | File[] | FileEntry[]): FileEntry[] {
+  if (file instanceof File) {
+    return [{file, path: file.name}];
+  } else if (Array.isArray(file)) {
+    return file.map((f) => {
+      if (f instanceof File) {
+        return {file: f, path: f.name};
+      } else {
+        return f;
+      }
+    });
+  } else {
+    throw new Error("Invalid input type, expected File, File[], or FileEntry[]");
+  }
 }


### PR DESCRIPTION
This handles formats that require multiple files, like [DICOM](https://openslide.org/formats/dicom/), [MIRAX](https://openslide.org/formats/mirax/), and [Hamamatsu VMS and VMU](https://openslide.org/formats/hamamatsu/).

This also adds a couple of helpful utility functions:
* `fileEntriesFromFiles` - a simple function that returns `FileEntry[]` from `File[]`.
* `applyAlpha` - a function that applies the alpha channel to RGBA returned by readRegion, per the guidance here: https://openslide.org/docs/premultiplied-argb/

Finally, due to added functionality, this bumps the version from `2.2.2` to `2.3.0`.