### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Conflux XYZ, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -160,3 +160,9 @@ function getDicomFiles(files: File[]): File[] {
 We strive to support all WSI file formats that are supported by the OpenSlide C library.
 
 If you find a format that works with the OpenSlide C library but not with OpenSlideWASM, please file an issue, and, even better, submit a pull request!
+
+## License
+
+The code in this repository is licensed under the [MIT License](./LICENSE).
+
+Note that OpenSlideWASM compiles [OpenSlide](https://openslide.org/) and its dependencies (see [`get_external_deps.sh`](./get_external_deps.sh)) to WebAssembly. Those projects are distributed under their own licenses — notably OpenSlide and glib, which are LGPL v2.1 — and those terms continue to apply to the compiled artifacts.


### PR DESCRIPTION
## Summary

`openslide-wasm/package.json` already declares `"license": "MIT"`, but the repo had no `LICENSE` file — so GitHub showed no license for the project and there was nothing authoritative for consumers to point at.

- Adds the standard MIT license text, `Copyright (c) 2025 Conflux XYZ, Inc.`
- Adds a `## License` section to the README

## Note on bundled dependencies

The README section also records that this MIT license covers the code in this repo, and that the dependencies compiled into the WASM artifacts (see `get_external_deps.sh`) keep their own terms — notably OpenSlide and glib, which are LGPL v2.1. Worth a look in review in case you want different wording, or a copyright holder other than "Conflux XYZ, Inc."

🤖 Generated with [Claude Code](https://claude.com/claude-code)